### PR TITLE
Fixed profile card desktop

### DIFF
--- a/public/assets/css/styles.css
+++ b/public/assets/css/styles.css
@@ -158,6 +158,7 @@ body {
 @media screen and (min-width: 48em) {
   .profile__card {
     justify-content: space-between;
+    min-height: auto;
     height: 100%;
   }
 }


### PR DESCRIPTION
added `min-height: auto;` to media query so that standard `min-height` overwritten.